### PR TITLE
Fix missing ImportoTotaleDocumento in xml

### DIFF
--- a/src/Body/DatiGeneraliDocumento.php
+++ b/src/Body/DatiGeneraliDocumento.php
@@ -703,7 +703,7 @@ class DatiGeneraliDocumento
             $array['ScontoMaggiorazione']['Importo'] = number_format($this->getScontoImporto(), 2, '.', '');
         }
 
-        if (!$this->getImportoTotaleDocumento() === null) {
+        if (!($this->getImportoTotaleDocumento() === null)) {
             $array['ImportoTotaleDocumento'] = number_format($this->getImportoTotaleDocumento(), 2, '.', '');
         }
         if (!empty($this->getArrotondamento())) {


### PR DESCRIPTION
The logic for inclusion is reversed. ImportoTotaleDocumento was not included in the invoice header. Patch attached.