### PR TITLE
DatiDDT in DatiGeneraliDocumento can occur multiple types : Convert DatiDDT to array.

### DIFF
--- a/src/Body/DatiDDT.php
+++ b/src/Body/DatiDDT.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Created by    Gabriel Andrei gabrielandrei79@gmail.com
+ * Date:         04/11/2018
+ * Time:         16:01
+ */
+
+namespace Advinser\FatturaElettronicaXml\Body;
+
+class DatiDDT
+{
+    /**
+     * @var null|string
+     */
+    private $NumeroDDT = null;
+    /**
+     * @var null|string
+     */
+    private $DataDDT = null;
+    /**
+     * @var null|string
+     */
+    private $RiferimentoNumeroLinea = null;
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'NumeroDDT' => $this->getNumeroDDT(),
+            'DataDDT' => $this->getDataDDT(),
+            'RiferimentoNumeroLinea' => $this->getRiferimentoNumeroLinea(),
+        ];
+    }
+
+    public static function fromArray(array $array): DatiDDT
+    {
+        $o = new DatiDDT();
+
+        if (isset($array['NumeroDDT'])) {
+            $o->setNumeroDDT($array['NumeroDDT']);
+        }
+
+        if (isset($array['DataDDT'])) {
+            $o->setDataDDT($array['DataDDT']);
+        }
+
+        if (isset($array['RiferimentoNumeroLinea'])) {
+            $o->setRiferimentoNumeroLinea($array['RiferimentoNumeroLinea']);
+        }
+
+        return $o;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getNumeroDDT(): ?string
+    {
+        return $this->NumeroDDT;
+    }
+
+    /**
+     * @param null|string $NumeroDDT
+     * @return DatiGenerali
+     */
+    public function setNumeroDDT(?string $NumeroDDT): DatiDDT
+    {
+        $this->NumeroDDT = $NumeroDDT;
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getDataDDT(): ?string
+    {
+        return $this->DataDDT;
+    }
+
+    /**
+     * @param null|string $DataDDT
+     * @return DatiGenerali
+     */
+    public function setDataDDT(?string $DataDDT): DatiDDT
+    {
+        $this->DataDDT = $DataDDT;
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getRiferimentoNumeroLinea(): ?string
+    {
+        return $this->RiferimentoNumeroLinea;
+    }
+
+    /**
+     * @param null|string $RiferimentoNumeroLinea
+     * @return DatiGenerali
+     */
+    public function setRiferimentoNumeroLinea(?string $RiferimentoNumeroLinea): DatiDDT
+    {
+        $this->RiferimentoNumeroLinea = $RiferimentoNumeroLinea;
+        return $this;
+    }
+}

--- a/src/Body/DatiGenerali.php
+++ b/src/Body/DatiGenerali.php
@@ -10,6 +10,7 @@ namespace Advinser\FatturaElettronicaXml\Body;
 
 use Advinser\FatturaElettronicaXml\FatturaElettronicaException;
 use Advinser\FatturaElettronicaXml\Structures\DatiRiferimento;
+use Advinser\FatturaElettronicaXml\Body\DatiDDT;
 
 class DatiGenerali
 {
@@ -45,18 +46,11 @@ class DatiGenerali
      * @var null|string
      */
     private $RiferimentoFase = null;
+
     /**
-     * @var null|string
+     * @var DatiDDT[] | null
      */
-    private $NumeroDDT = null;
-    /**
-     * @var null|string
-     */
-    private $DataDDT = null;
-    /**
-     * @var null|string
-     */
-    private $RiferimentoNumeroLinea = null;
+    private $DatiDDT ;
 
     /**
      * @var DatiTrasporto|null
@@ -72,6 +66,34 @@ class DatiGenerali
      * @var string|null
      */
     private $DataFatturaPrincipale;
+
+    /**
+     * @return DatiDDT[]|null
+     */
+    public function getDatiDDT(): ?array
+    {
+        return $this->DatiDDT;
+    }
+
+    /**
+     * @param DatiDDT[]|null $datiDDT
+     * @return DatiDDT
+     */
+    public function setDatiDDT(?array $datiDDT): DatiGenerali
+    {
+        $this->DatiDDT = $datiDDT;
+        return $this;
+    }
+
+    /**
+     * @param DatiDDT $datiDDT
+     * @return DatiGenerali
+     */
+    public function addDatiDDT(DatiDDT $datiDDT): DatiGenerali
+    {
+        $this->DatiDDT[] = $datiDDT;
+        return $this;
+    }
 
     /**
      * @return DatiGeneraliDocumento|null
@@ -211,60 +233,6 @@ class DatiGenerali
     }
 
     /**
-     * @return null|string
-     */
-    public function getNumeroDDT(): ?string
-    {
-        return $this->NumeroDDT;
-    }
-
-    /**
-     * @param null|string $NumeroDDT
-     * @return DatiGenerali
-     */
-    public function setNumeroDDT(?string $NumeroDDT): DatiGenerali
-    {
-        $this->NumeroDDT = $NumeroDDT;
-        return $this;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getDataDDT(): ?string
-    {
-        return $this->DataDDT;
-    }
-
-    /**
-     * @param null|string $DataDDT
-     * @return DatiGenerali
-     */
-    public function setDataDDT(?string $DataDDT): DatiGenerali
-    {
-        $this->DataDDT = $DataDDT;
-        return $this;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getRiferimentoNumeroLinea(): ?string
-    {
-        return $this->RiferimentoNumeroLinea;
-    }
-
-    /**
-     * @param null|string $RiferimentoNumeroLinea
-     * @return DatiGenerali
-     */
-    public function setRiferimentoNumeroLinea(?string $RiferimentoNumeroLinea): DatiGenerali
-    {
-        $this->RiferimentoNumeroLinea = $RiferimentoNumeroLinea;
-        return $this;
-    }
-
-    /**
      * @return DatiTrasporto|null
      */
     public function getDatiTrasporto(): ?DatiTrasporto
@@ -371,14 +339,17 @@ class DatiGenerali
         if (!empty($this->getRiferimentoFase())) {
             $array['DatiSAL']['RiferimentoFase'] = $this->getRiferimentoFase();
         }
-        if (!empty($this->getNumeroDDT())) {
-            $array['DatiDDT']['NumeroDDT'] = $this->getNumeroDDT();
-        }
-        if (!empty($this->getDataDDT())) {
-            $array['DatiDDT']['NumeroDDT'] = $this->getDataDDT();
-        }
-        if (!empty($this->getRiferimentoNumeroLinea())) {
-            $array['DatiDDT']['RiferimentoNumeroLinea'] = $this->getRiferimentoNumeroLinea();
+
+        if (!empty($this->getDatiDDT())) {
+            if (count($this->getDatiDDT()) === 1) {
+                $array['DatiDDT'] = $this->getDatiDDT()[0]->toArray();
+            } else {
+                $a = [];
+                foreach ($this->getDatiDDT() as $DatiDDT) {
+                    $a[] = $DatiDDT->toArray();
+                }
+                $array['DatiDDT'] = $a;
+            }
         }
 
         if ($this->getDatiTrasporto() instanceof DatiTrasporto) {
@@ -426,16 +397,17 @@ class DatiGenerali
         if (!empty($array['DatiSAL']['RiferimentoFase'])) {
             $o->setRiferimentoFase($array['DatiSAL']['RiferimentoFase']);
         }
-        if (!empty($array['DatiDDT']['NumeroDDT'])) {
-            $o->setNumeroDDT($array['DatiDDT']['NumeroDDT']);
-        }
-        if (!empty($array['DatiDDT']['NumeroDDT'])) {
-            $o->setDataDDT($array['DatiDDT']['NumeroDDT']);
-        }
-        if (!empty($array['DatiDDT']['RiferimentoNumeroLinea'])) {
-            $o->setRiferimentoNumeroLinea($array['DatiDDT']['RiferimentoNumeroLinea']);
-        }
 
+        if (isset($array['DatiDDT'])) {
+            if (isset($array['DatiDDT'][0])) {
+                foreach ($array['DatiDDT'] as $item) {
+                    $o->addDatiDDT(DatiDDT::fromArray($item));
+                }
+            } else {
+                $o->addDatiDDT(DatiDDT::fromArray($array['DatiDDT']));
+            }
+        }
+        
         if (!empty($array['DatiTrasporto'])) {
             $o->setDatiTrasporto(DatiTrasporto::fromArray($array['DatiTrasporto']));
         }


### PR DESCRIPTION
DatiGeneraliDocumento currenly allows for a single DatiDDT "type". The 1.2.1 specification provides for multiple DDTs, each of which can be related to a single line. Typically, in a summary (end of month) invoice you'll have multiple lines, and multiple DDTs, each DDT linked to a single line which represents a single shipment.

The fix is to create a DatiDDT class, and threat it as an array in DatiGeneraliDocumento. 

I am providing a PR for this functionality, implemented following the standards you use in the DettaglioLinee array.
